### PR TITLE
Add Camel Spring Boot Contract First Template

### DIFF
--- a/template-index.yaml
+++ b/template-index.yaml
@@ -11,3 +11,4 @@ spec:
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-consumer/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-producer/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-camel-api-consumer/template.yaml
+    - https://github.com/contract-first-idp/software-templates/blob/main/templates/camel-spring-boot-api-producer/template.yaml

--- a/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-dev.yaml
+++ b/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-dev.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.component_id }}-dev
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-idp/${{ values.component_id }}
+    targetRevision: HEAD
+    path: .helm
+    helm:
+      values: | 
+        image: 
+          repository: image-registry.openshift-image-registry.svc:5000/${{values.application.split("/")[1]}}-dev/${{ values.component_id }}
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-dev
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-pipeline.yaml
+++ b/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-pipeline.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.component_id }}-pipeline
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-idp/${{ values.component_id }}
+    targetRevision: HEAD
+    path: .tekton
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-build
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.component_id }}-prod
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-idp/${{ values.component_id }}
+    targetRevision: HEAD
+    path: .helm
+    helm:
+      values: | 
+        image: 
+          repository: image-registry.openshift-image-registry.svc:5000/${{values.application.split("/")[1]}}-prod/${{ values.component_id }}
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-prod
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/camel-spring-boot-api-producer/app-gitops/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{ values.component_id }}-qa
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-idp/${{ values.component_id }}
+    targetRevision: HEAD
+    path: .helm
+    helm:
+      values: | 
+        image: 
+          repository: image-registry.openshift-image-registry.svc:5000/${{values.application.split("/")[1]}}-qa/${{ values.component_id }}
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-qa
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/camel-spring-boot-api-producer/skeleton/.devfile.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.devfile.yaml
@@ -1,0 +1,74 @@
+schemaVersion: 2.2.0
+metadata:
+  name: ${{values.component_id}}
+  version: 0.0.1
+  displayName: CSB Java ubi8
+  description: CSB and ubi8 image
+  generateName: ${{values.component_id}}
+  icon: >-
+    https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/java-maven.jpg
+  tags:
+    - Java
+    - Spring
+    - Camel
+  projectType: spring
+  language: java
+attributes:
+  controller.devfile.io/storage-type: ephemeral
+components:
+  - name: development-tooling
+    container:
+      image: registry.redhat.io/devspaces/udi-rhel8:latest
+      env:
+        - name: MAVEN_OPTS
+          value: "-Dmaven.repo.local=/home/user/.m2/repository"
+      memoryLimit: 5Gi
+      cpuLimit: 2500m
+      sourceMapping: $PROJECT_SOURCE
+      mountSources: true
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      endpoints:
+        - name: http-8778
+          targetPort: 8778
+        - name: devtools
+          targetPort: 8000
+        - name: http
+          targetPort: 8080
+          exposure: public
+          secure: false
+          protocol: http
+        - name: management
+          targetPort: 8081
+          secure: false
+          protocol: http
+        - name: http-8443
+          targetPort: 8443
+  - name: m2
+    volume:
+      size: 1G
+commands:
+  - id: package
+    exec:
+      label: "1. Package the application"
+      component: development-tooling
+      commandLine: "./mvnw package"
+      group:
+        kind: build
+        isDefault: true
+  - id: start-dev
+    exec:
+      label: "2. Run Spring Boot application"
+      component: development-tooling
+      commandLine: "./mvnw compile spring-boot:run"
+      group:
+        kind: run
+        isDefault: true
+  - id: fix-java-version
+    exec:
+      component: development-tooling
+      commandLine: 'rm -rf ${HOME}/.java/current/* && ln -s /usr/lib/jvm/java-17-openjdk/* ${HOME}/.java/current'
+events:
+  postStart:
+    - fix-java-version

--- a/templates/camel-spring-boot-api-producer/skeleton/.dockerignore
+++ b/templates/camel-spring-boot-api-producer/skeleton/.dockerignore
@@ -1,0 +1,2 @@
+*
+!target/*.jar

--- a/templates/camel-spring-boot-api-producer/skeleton/.gitignore
+++ b/templates/camel-spring-boot-api-producer/skeleton/.gitignore
@@ -1,0 +1,40 @@
+#Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+.flattened-pom.xml
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# NetBeans
+nb-configuration.xml
+
+# Visual Studio Code
+.vscode
+.factorypath
+
+# OSX
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Local environment
+.env

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/.helmignore
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/Chart.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: helm
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/deployment.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+            - name: management
+              containerPort: {{ .Values.managementPort }}
+          env:
+            # Define environment variables here if needed
+          resources:
+            requests:
+              memory: "{{ .Values.resources.requests.memory }}"
+              cpu: "{{ .Values.resources.requests.cpu }}"
+            limits:
+              memory: "{{ .Values.resources.limits.memory }}"
+              cpu: "{{ .Values.resources.limits.cpu }}"
+      # Add additional settings like volumes, secrets, etc. if necessary

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/rolebinding.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-pipeline-registry-access
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: ${{values.application.split("/")[1]}}-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/route.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  port:
+    targetPort: {{ .Values.containerPort }} 
+  to:
+    kind: Service
+    name: {{ .Release.Name }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/service.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ .Release.Name }}
+  name: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.containerPort }}
+      protocol: TCP
+      targetPort: {{ .Values.containerPort }}
+    - port: {{ .Values.managementPort }}
+      protocol: TCP
+      targetPort: {{ .Values.managementPort }}
+  selector:
+    app: {{ .Release.Name }}

--- a/templates/camel-spring-boot-api-producer/skeleton/.helm/values.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.helm/values.yaml
@@ -1,0 +1,20 @@
+# Define the image repository and tag for your Java application.
+image:
+  repository: quay.io/maximilianb/hqoas-spring-demo
+  tag: latest
+
+# Define the container port your Java application listens on.
+containerPort: 8080
+managementPort: 8081
+
+# Specify the number of replicas (pods) for your Java application.
+replicaCount: 1
+
+# Define resource requests and limits for your Java application containers.
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "200m"

--- a/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/.gitignore
+++ b/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/.gitignore
@@ -1,0 +1,1 @@
+maven-wrapper.jar

--- a/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader
+{
+    private static final String WRAPPER_VERSION = "3.1.1";
+
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL =
+        "https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/" + WRAPPER_VERSION
+            + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to use instead of the
+     * default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH = ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH = ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main( String args[] )
+    {
+        System.out.println( "- Downloader started" );
+        File baseDirectory = new File( args[0] );
+        System.out.println( "- Using base directory: " + baseDirectory.getAbsolutePath() );
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File( baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH );
+        String url = DEFAULT_DOWNLOAD_URL;
+        if ( mavenWrapperPropertyFile.exists() )
+        {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try
+            {
+                mavenWrapperPropertyFileInputStream = new FileInputStream( mavenWrapperPropertyFile );
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load( mavenWrapperPropertyFileInputStream );
+                url = mavenWrapperProperties.getProperty( PROPERTY_NAME_WRAPPER_URL, url );
+            }
+            catch ( IOException e )
+            {
+                System.out.println( "- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'" );
+            }
+            finally
+            {
+                try
+                {
+                    if ( mavenWrapperPropertyFileInputStream != null )
+                    {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                }
+                catch ( IOException e )
+                {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println( "- Downloading from: " + url );
+
+        File outputFile = new File( baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH );
+        if ( !outputFile.getParentFile().exists() )
+        {
+            if ( !outputFile.getParentFile().mkdirs() )
+            {
+                System.out.println( "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath()
+                    + "'" );
+            }
+        }
+        System.out.println( "- Downloading to: " + outputFile.getAbsolutePath() );
+        try
+        {
+            downloadFileFromURL( url, outputFile );
+            System.out.println( "Done" );
+            System.exit( 0 );
+        }
+        catch ( Throwable e )
+        {
+            System.out.println( "- Error downloading" );
+            e.printStackTrace();
+            System.exit( 1 );
+        }
+    }
+
+    private static void downloadFileFromURL( String urlString, File destination )
+        throws Exception
+    {
+        if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
+        {
+            String username = System.getenv( "MVNW_USERNAME" );
+            char[] password = System.getenv( "MVNW_PASSWORD" ).toCharArray();
+            Authenticator.setDefault( new Authenticator()
+            {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication()
+                {
+                    return new PasswordAuthentication( username, password );
+                }
+            } );
+        }
+        URL website = new URL( urlString );
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel( website.openStream() );
+        FileOutputStream fos = new FileOutputStream( destination );
+        fos.getChannel().transferFrom( rbc, 0, Long.MAX_VALUE );
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/maven-wrapper.properties
+++ b/templates/camel-spring-boot-api-producer/skeleton/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/templates/camel-spring-boot-api-producer/skeleton/.tekton/README.md
+++ b/templates/camel-spring-boot-api-producer/skeleton/.tekton/README.md
@@ -1,0 +1,23 @@
+# Tekton-pipeline
+
+This repo builds the backstage image we use for janus IDP.
+
+## Requirements
+
+- Install tekton pipelines. You can find a reference from here: https://docs.openshift.com/container-platform/4.9/cicd/pipelines/installing-pipelines.html
+- Container registry authentication configured. In our case we created a file named quay-credentials.yml. You can find how to set it up from here: https://access.redhat.com/documentation/en-us/red_hat_quay/3.4/html-single/use_red_hat_quay/index#allow-robot-access-user-repo
+
+## Build the image
+
+
+```console
+$ kubectl apply -f quay-credentials.yml
+
+$ kubectl apply -f maven-pipeline.yaml
+
+$ kubectl create -f pipelinerun.yaml
+
+$ pipelinerun.tekton.dev/clone-build-push-run-4kgjr created
+
+$ tkn pipelinerun logs  clone-build-push-run-4kgjr -f
+```

--- a/templates/camel-spring-boot-api-producer/skeleton/.tekton/maven-pipeline.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/.tekton/maven-pipeline.yaml
@@ -1,0 +1,82 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: ${{ values.component_id }}-pipeline
+spec:
+  workspaces:
+  - name: maven-repo
+  - name: maven-settings
+
+  params:
+    - default: ./src/main/docker/Dockerfile
+      name: dockerfilePath
+      type: string
+      description: Path containing the Dockerfile for the final image
+    - default: https://github.com/contract-first-idp/${{ values.component_id }}
+      name: git-url
+      type: string
+      description: "Upstream Source Repository Url"
+    - default: master
+      name: git-revision
+      type: string
+      description: "Upstream source code revision to pull"
+    - default: image-registry.openshift-image-registry.svc:5000/${{values.application.split("/")[1]}}-dev/${{ values.component_id }}:latest
+      name: image-name
+      type: string
+      description: "Target OCI image name"
+
+  tasks:
+  - name: clone
+    taskRef:
+      name: git-clone
+      kind: ClusterTask
+    params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.git-revision)
+    workspaces:
+    - name: output
+      workspace: maven-repo
+
+  - name: build
+    taskRef:
+      name: maven
+      kind: ClusterTask
+    runAfter: ["clone"]
+    params:
+    - name: GOALS
+      value: ["compile"]
+    workspaces:
+    - name: source
+      workspace: maven-repo
+    - name: maven-settings
+      workspace: maven-settings
+
+  - name: package
+    taskRef:
+      name: maven
+      kind: ClusterTask
+    runAfter: ["build"]
+    params:
+    - name: GOALS
+      value: ["package"]
+    workspaces:
+    - name: source
+      workspace: maven-repo
+    - name: maven-settings
+      workspace: maven-settings
+
+  - name: build-container-image
+    runAfter: ["package"]
+    taskRef:
+      name: buildah
+      kind: ClusterTask
+    workspaces:
+    - name: source
+      workspace: maven-repo
+    params:
+    - name: IMAGE
+      value: $(params.image-name)
+    - name: DOCKERFILE
+      value: $(params.dockerfilePath)

--- a/templates/camel-spring-boot-api-producer/skeleton/catalog-info.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{values.component_id | dump}}
+  description: ${{values.description | dump}}
+  tags:
+    - java
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{values.owner | dump}}
+  system: ${{values.application}}
+  providesApis: 
+    - ${{values.api_id}}

--- a/templates/camel-spring-boot-api-producer/skeleton/mvnw
+++ b/templates/camel-spring-boot-api-producer/skeleton/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/templates/camel-spring-boot-api-producer/skeleton/mvnw.cmd
+++ b/templates/camel-spring-boot-api-producer/skeleton/mvnw.cmd
@@ -1,0 +1,205 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%

--- a/templates/camel-spring-boot-api-producer/skeleton/pom.xml
+++ b/templates/camel-spring-boot-api-producer/skeleton/pom.xml
@@ -1,0 +1,213 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.redhat</groupId>
+    <artifactId>${{ values.component_id }}</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>${{ values.component_id }}</name>
+  
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <spring.boot-version>3.3.1</spring.boot-version>
+      <camel.spring.boot-version>4.7.0</camel.spring.boot-version>
+      <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
+      <java.version>17</java.version>
+      <maven.compiler.source>${java.version}</maven.compiler.source>
+      <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+  
+    <dependencyManagement>
+      <dependencies>
+        <!-- Camel BOM -->
+        <dependency>
+          <groupId>org.apache.camel.springboot</groupId>
+          <artifactId>camel-spring-boot-bom</artifactId>
+          <version>${camel.spring.boot-version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+        <!-- Spring Boot BOM -->
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-dependencies</artifactId>
+          <version>${spring.boot-version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+  
+    <dependencies>
+  
+      <!-- Spring Boot -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-undertow</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+      </dependency>
+  
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-spring-boot-starter</artifactId>
+      </dependency>
+
+      <!-- Camel Contract First dependencies -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-platform-http-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-rest-openapi-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-yaml-dsl-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-jackson-starter</artifactId>
+      </dependency>
+
+      <!-- Camel Monitoring dependencies -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-micrometer-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-opentelemetry-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-controlbus-starter</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-openapi-java-starter</artifactId>
+      </dependency>
+  
+      <!--
+      This dependency is mandatory for enabling Camel management
+      via JMX / Hawtio.
+      -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-management-starter</artifactId>
+      </dependency>
+      <!--
+      This dependency is required for viewing Camel routes source XML.
+      -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-spring-boot-xml-starter</artifactId>
+      </dependency>
+      <!--
+      To enable Camel plugin debugging feature, add this dependency.
+      -->
+      <dependency>
+        <groupId>org.apache.camel.springboot</groupId>
+        <artifactId>camel-debug-starter</artifactId>
+      </dependency>
+  
+      <!-- Test -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-test-spring-junit5</artifactId>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>io.swagger.codegen.v3</groupId>
+          <artifactId>swagger-codegen-maven-plugin</artifactId>
+          <version>3.0.52</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+              <configuration>
+                <language>spring</language>
+                <library>spring-boot3</library>
+                <inputSpec>https://raw.githubusercontent.com/contract-first-idp/${{ values.api_id }}/master/specification.yaml</inputSpec>
+                <modelPackage>com.redhat.model</modelPackage>
+                <generateApis>false</generateApis>
+                <generateApiDocumentation>false</generateApiDocumentation>
+                <generateModelDocumentation>false</generateModelDocumentation>
+                <generateApiTests>false</generateApiTests>
+                <generateModelTests>false</generateModelTests>
+                <generateSupportingFiles>false</generateSupportingFiles>
+                <generateModels>true</generateModels>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.5.0</version>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>target/swagger/src/main/java</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring.boot-version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  
+</project>

--- a/templates/camel-spring-boot-api-producer/skeleton/src/main/docker/Dockerfile
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/main/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
+
+USER root
+
+ADD https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.0.3/jolokia-agent-jvm-2.0.3-javaagent.jar /opt/jolokia/jolokia-javaagent.jar
+
+RUN \
+    chown default:default -R /opt/jolokia \
+    && chmod -R go+r /opt/jolokia/jolokia-javaagent.jar
+
+ENV JAVA_OPTS_APPEND="-javaagent:/opt/jolokia/jolokia-javaagent.jar=host=0.0.0.0,port=8778,protocol=https,useSslClientAuthentication=true,caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
+COPY --chown=185 target/${{ values.component_id }}*.jar /deployments/bundle.jar
+
+USER 185
+
+EXPOSE 8778 8080 8081
+
+ENV JAVA_APP_JAR="/deployments/bundle.jar"

--- a/templates/camel-spring-boot-api-producer/skeleton/src/main/java/com/redhat/MyCamelSpringBootApplication.java
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/main/java/com/redhat/MyCamelSpringBootApplication.java
@@ -1,0 +1,18 @@
+package com.redhat;
+
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@CamelOpenTelemetry
+@SpringBootApplication
+public class MyCamelSpringBootApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MyCamelSpringBootApplication.class, args);
+    }
+
+}

--- a/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/application.properties
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+camel.springboot.sourceLocationEnabled=true
+
+server.port=8080
+management.server.port=8081
+management.endpoints.web.exposure.include=*
+
+camel.springboot.use-mdc-logging =true
+camel.component.micrometer.enabled=true
+camel.component.metrics.metric-registry=prometheusMeterRegistry
+camel.metrics.enable-message-history=true
+management.endpoint.metrics.enabled=true

--- a/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/camel/rest-configuration.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/camel/rest-configuration.yaml
@@ -1,0 +1,11 @@
+- restConfiguration:
+    apiContextPath: /api-doc
+    #bindingMode: json
+    #bindingPackageScan: com.redhat.model
+
+- rest:
+    id: rest-openapi
+    openApi:
+      id: openapi-configuration
+      specification: https://raw.githubusercontent.com/contract-first-idp/${{ values.api_id }}/master/specification.yaml
+      missingOperation: ignore

--- a/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/camel/routes.yaml
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/main/resources/camel/routes.yaml
@@ -1,0 +1,25 @@
+# Add openapi implementation here with direct routes
+#- route:
+#    from:
+#      id: listPetsRoute
+#      uri: direct:listPets
+#      steps:
+#        - log:
+#            message: "do something here"
+#        - setBody:
+#            id: listPetsResponse
+#            expression:
+#              constant:
+#                expression: |
+#                  [
+#                    {
+#                      "id": 1,
+#                      "name": "foo",
+#                      "tag": "dog"
+#                    },
+#                    {
+#                      "id": 1,
+#                      "name": "bar",
+#                      "tag": "cat"
+#                    }
+#                  ]

--- a/templates/camel-spring-boot-api-producer/skeleton/src/test/java/com/redhat/OpenApiTest.java
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/test/java/com/redhat/OpenApiTest.java
@@ -1,0 +1,29 @@
+package com.redhat;
+
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@CamelSpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class OpenApiTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    public void testFullIntegration() {
+        String getResponse = this.restTemplate
+                .getForObject("http://localhost:" + port + "/api-doc", String.class);
+
+        Assertions.assertThat(getResponse).isNotNull();
+    }
+
+}

--- a/templates/camel-spring-boot-api-producer/skeleton/src/test/resources/application.properties
+++ b/templates/camel-spring-boot-api-producer/skeleton/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+camel.springboot.sourceLocationEnabled=true

--- a/templates/camel-spring-boot-api-producer/template.yaml
+++ b/templates/camel-spring-boot-api-producer/template.yaml
@@ -1,0 +1,128 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: spring-boot-api-producer-template
+  title: Spring Boot REST server
+  description: Create a simple RESTful microservice using Spring Boot
+spec:
+  owner: service@example.com
+  type: service
+  
+  parameters:
+    - title: API server parameters
+      required:
+        - component_id
+        - owner
+        - java_package_name
+        - application
+        - description
+        - api
+      properties:
+        component_id:
+          title: Name
+          type: string
+          description: Unique name of the component
+        java_package_name:
+          title: Java Package Name
+          type: string
+          description: Name for the java package. eg (io.backstage.blah)
+        description:
+          title: Description
+          type: string
+          description: Help others understand what this component does
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the component
+          ui:field: OwnerPicker
+          ui:options:
+            allowedKinds: 
+              - Group
+        application:
+          title: System
+          type: string
+          description: System to which this Component belongs
+          ui:field: OwnedEntityPicker
+          ui:options:
+            allowedKinds:
+            - System
+        api:
+          title: API
+          type: string
+          description: The API being implemented
+          ui:field: OwnedEntityPicker
+          ui:options:
+            allowedKinds:
+            - API
+
+  steps:
+    - id: template
+      name: Render Component Template
+      action: fetch:template
+      input:
+        url: ./skeleton
+        copyWithoutRender: []
+        values:
+          component_id: ${{ parameters.component_id }}
+          description: ${{ parameters.description }}
+          artifact_id: ${{ parameters.component_id }}
+          java_package_name: ${{ parameters.java_package_name }}
+          owner: ${{ parameters.owner }}
+          destination: https://github.com/contract-first-idp/${{ parameters.component_id }}
+          application: ${{ parameters.application }}
+          api_id: ${{ parameters.api.split("/")[1] }}
+
+    - id: publish
+      name: Publish Component Repository
+      action: publish:github
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.component_id }}
+        repoUrl: github.com?repo=${{ parameters.component_id }}&owner=contract-first-idp
+        repoVisibility: public
+        deleteBranchOnMerge: true
+        #access: contract-first-idp/${{ parameters.owner }}
+        protectDefaultBranch: false
+
+    - id: register
+      name: Register Component
+      action: catalog:register
+      input:
+        repoContentsUrl: '${{ steps.publish.output.repoContentsUrl }}'
+        catalogInfoPath: '/catalog-info.yaml'
+
+    - id: template-tenant-gitops 
+      name: Render GitOps Template
+      action: fetch:template
+      input:
+        url: ./app-gitops
+        copyWithoutRender: []
+        values:
+          component_id: ${{ parameters.component_id }}
+          description: ${{ parameters.description }}
+          artifact_id: ${{ parameters.component_id }}
+          java_package_name: ${{ parameters.java_package_name }}
+          owner: ${{ parameters.owner }}
+          application: ${{ parameters.application }}
+          organization: contract-first-idp
+          team: ${{ parameters.owner }}
+          repo_id: ${{ parameters.component_id }}
+        targetPath: ./tenant-gitops
+
+    - id: pull-request
+      name: Open PR to System
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-gitops&owner=contract-first-idp
+        branchName: ${{ parameters.component_id }}
+        title: argocd apps for ${{ parameters.component_id }}
+        description: argocd apps ${{ parameters.component_id }}
+        sourcePath: ./tenant-gitops
+
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}

--- a/templates/camel-spring-boot-api-producer/template.yaml
+++ b/templates/camel-spring-boot-api-producer/template.yaml
@@ -2,8 +2,8 @@ apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: spring-boot-api-producer-template
-  title: Spring Boot REST server
-  description: Create a simple RESTful microservice using Spring Boot
+  title: A Camel Spring Boot REST server
+  description: Create a simple API first microservice using Camel Spring Boot
 spec:
   owner: service@example.com
   type: service


### PR DESCRIPTION
The following template exposes a given openapi.yaml definition (for example https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml). The idea is that by default all the API are exposed, considering the petstore for example `/v1/pets` is exposed but an implementation is needed. In order to implement an API the file routes.yaml can be used, the commented example mocks `List all Pets` from the petstore.yaml. The idea is that the API is exposed out of the box and the user has to implement the business logic in the form of
```
from("direct:$operationId")...to("$businessLogic")
```

For example, camel-jpa can be easily added and the bindingMode can be uncommented, so that jackson automatically marhsal/unmarshall requests and response, and the data can be easily saved into the database ala:
```
- route:
    id: createPets-route
    from:
      id: createPets-direct
      uri: direct
      parameters:
        name: createPets
      steps:
        - to:
            id: createPets-jpa
            uri: jpa
            parameters:
              entityType: com.redhat.model.Pet
```