### PR TITLE
Add Native Profile

### DIFF
--- a/templates/quarkus-camel-api-consumer/skeleton/pom.xml
+++ b/templates/quarkus-camel-api-consumer/skeleton/pom.xml
@@ -258,4 +258,18 @@
             {%- endif %}
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
@davgordo this was lost during a rebase, sorry! but the overall native workflow is working as expected, and here you can see the startup improvment

`2024-09-19 17:11:06,004 INFO [io.quarkus] (main) quarkus-native 1.0-SNAPSHOT native (powered by Quarkus 3.14.1) started in 0.181s. Listening on: http://0.0.0.0:8080/`
versus
`2024-09-19 16:00:08,793 INFO [io.quarkus] (main) quarkus-jvm 1.0-SNAPSHOT on JVM (powered by Quarkus 3.14.1) started in 21.198s. Listening on: http://0.0.0.0:8080/`