### PR TITLE
Camel F2F Improvement Backports

### DIFF
--- a/template-index.yaml
+++ b/template-index.yaml
@@ -10,6 +10,7 @@ spec:
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/api-specification/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/quarkus-camel-api-producer/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/quarkus-camel-api-consumer/template.yaml
+    - https://github.com/contract-first-idp/software-templates/blob/main/templates/quarkus-camel-openapi/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-consumer/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-producer/template.yaml
     - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-camel-api-consumer/template.yaml

--- a/templates/api-specification/skeleton/catalog-info.yaml
+++ b/templates/api-specification/skeleton/catalog-info.yaml
@@ -10,6 +10,6 @@ spec:
   type: openapi
   system: ${{values.application}}
   owner: ${{values.owner | dump}}
-  lifecycle: experimental
+  lifecycle: production
   definition:
     $openapi: ${{ values.destination }}/blob/main/specification.yaml

--- a/templates/api-specification/skeleton/catalog-info.yaml
+++ b/templates/api-specification/skeleton/catalog-info.yaml
@@ -6,6 +6,15 @@ metadata:
   description: ${{values.description | dump}}
   annotations:
     backstage.io/spectral-ruleset-url: https://raw.githubusercontent.com/contract-first-idp/spectral-rules/main/ruleset.yaml
+  links:
+    - url: ${{ values.service_registry_provider_url }}/ui/artifacts/${{ values.group_id }}/${{ values.api_id }}/versions/latest
+      title: Apicurio Registry
+      icon: web
+    - url: ${{ values.mock_provider_url }}/#/services?name=${{ values.api_id }}
+      title: Microcks
+    - url: ${{ values.mock_provider_url }}/rest/ratings/v1
+      title: Mock
+      icon: web
 spec:
   type: openapi
   system: ${{values.application}}

--- a/templates/api-specification/skeleton/pom.xml
+++ b/templates/api-specification/skeleton/pom.xml
@@ -12,14 +12,11 @@
     <name>${{ values.api_id }}</name>
 
     <properties>
-        {%- if values.service_registry_provider_url %}
         <apicurio-registry-maven-plugin.version>2.6.4.Final</apicurio-registry-maven-plugin.version>
-        {%- endif %}
     </properties>
 
     <build>
         <plugins>
-            {%- if values.service_registry_provider_url %}
             <!--
             This plugin connects with the Service Registry and download
             the contracts (OpenApi) used in the project -->
@@ -49,7 +46,6 @@
                  </execution>
                 </executions>
             </plugin>
-            {%- endif %}
         </plugins>
     </build>
 </project>

--- a/templates/api-specification/system/apis/${{values.api_id}}-api-pipeline.yaml
+++ b/templates/api-specification/system/apis/${{values.api_id}}-api-pipeline.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
 spec:
   project: default
   source:

--- a/templates/api-specification/system/apis/${{values.api_id}}-api-pipeline.yaml
+++ b/templates/api-specification/system/apis/${{values.api_id}}-api-pipeline.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.api_id }}-api-pipeline
+  name: ${{values.application.split("/")[1]}}-${{ values.api_id }}-api-pipeline
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/templates/api-specification/template.yaml
+++ b/templates/api-specification/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: OpenAPI Specification
   description: Create an OpenAPI specification (v0.6)
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: api
 
   parameters:

--- a/templates/api-specification/template.yaml
+++ b/templates/api-specification/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: api-specification-template
   title: OpenAPI Specification
-  description: Create an OpenAPI specification (v0.1)
+  description: Create an OpenAPI specification (v0.2)
 spec:
   owner: service@example.com
   type: api

--- a/templates/api-specification/template.yaml
+++ b/templates/api-specification/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: api-specification-template
   title: OpenAPI Specification
-  description: Create an OpenAPI specification (v0.2)
+  description: Create an OpenAPI specification (v0.3)
 spec:
   owner: service@example.com
   type: api
@@ -56,7 +56,7 @@ spec:
         group_id:
           title: Apicurio Registry Group ID
           type: string
-          default: com.redhat.${{ parameters.application.split("/")[1] }}
+          default: com.redhat
         cluster_domain:
           title: Cluster domain
           type: string
@@ -122,7 +122,7 @@ spec:
           application: ${{ parameters.application }}
           service_registry_provider_url: https://registry-apicurio-registry.${{ parameters.cluster_domain }}
           mock_provider_url: https://microcks-microcks.${{ parameters.cluster_domain }}
-          group_id: ${{ parameters.group_id }}
+          group_id: ${{ parameters.group_id }}.${{ parameters.application.split("/")[1] }}
         targetPath: ./system-gitops
 
     - id: pr

--- a/templates/api-specification/template.yaml
+++ b/templates/api-specification/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: api-specification-template
   title: OpenAPI Specification
-  description: Create an OpenAPI specification
+  description: Create an OpenAPI specification (v0.1)
 spec:
   owner: service@example.com
   type: api
@@ -16,8 +16,6 @@ spec:
         - application
         - description
         - group_id
-        - mock_provider_url
-        - service_registry_provider_url
         - cluster_domain
 
       properties:
@@ -58,11 +56,12 @@ spec:
         group_id:
           title: Apicurio Registry Group ID
           type: string
-          default: com.redhat
+          default: com.redhat.${{ parameters.application.split("/")[1] }}
         cluster_domain:
           title: Cluster domain
           type: string
-          description: Cluster domain (like apps.example.com)  
+          description: Cluster domain (like apps.example.com)
+          default: apps.cluster-m22mk.m22mk.sandbox2534.opentlc.com
 
   steps:
     - id: template
@@ -103,7 +102,14 @@ spec:
         events: ['push']
         active: true
         contentType: 'json'
-        insecureSsl: false     
+        insecureSsl: true
+
+    - id: register
+      name: Register Component
+      action: catalog:register
+      input:
+        repoContentsUrl: '${{ steps.publish.output.repoContentsUrl }}'
+        catalogInfoPath: '/catalog-info.yaml'
 
     - id: template-system-pull-request
       name: render system pull request
@@ -114,12 +120,12 @@ spec:
         values:
           api_id: ${{ parameters.api_id }}
           application: ${{ parameters.application }}
-          service_registry_provider_url: ${{ parameters.service_registry_provider_url }}
-          mock_provider_url: ${{ parameters.mock_provider_url }}
+          service_registry_provider_url: https://registry-apicurio-registry.${{ parameters.cluster_domain }}
+          mock_provider_url: https://microcks-microcks.${{ parameters.cluster_domain }}
           group_id: ${{ parameters.group_id }}
         targetPath: ./system-gitops
 
-    - id: pull-request-to-system
+    - id: pr
       name: open system pull request
       action: publish:github:pull-request
       input:
@@ -129,3 +135,12 @@ spec:
         description: add ${{ parameters.api_id}} API
         sourcePath: ./system-gitops
 
+  output:
+    links:
+      - title: Pull Request to Domain
+        url: ${{ steps.pr.output.remoteUrl }}
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}

--- a/templates/api-specification/template.yaml
+++ b/templates/api-specification/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: api-specification-template
   title: OpenAPI Specification
-  description: Create an OpenAPI specification (v0.3)
+  description: Create an OpenAPI specification (v0.6)
 spec:
   owner: service@example.com
   type: api
@@ -73,11 +73,11 @@ spec:
         values:
           api_id: ${{ parameters.api_id }}
           description: ${{ parameters.description }}
-          mock_provider_url: ${{ parameters.mock_provider_url }}
           owner: ${{ parameters.owner }}
           destination: https://github.com/contract-first-idp/${{ parameters.application.split("/")[1] }}-${{ parameters.api_id }}-api
           application: ${{ parameters.application }}
-          service_registry_provider_url: ${{ parameters.service_registry_provider_url }}
+          service_registry_provider_url: https://registry-apicurio-registry.${{ parameters.cluster_domain }}
+          mock_provider_url: https://microcks-microcks.${{ parameters.cluster_domain }}
           group_id: ${{ parameters.group_id }}
 
     - id: publish
@@ -137,7 +137,7 @@ spec:
 
   output:
     links:
-      - title: Pull Request to Domain
+      - title: Pull Request to System
         url: ${{ steps.pr.output.remoteUrl }}
       - title: Repository
         url: ${{ steps.publish.output.remoteUrl }}

--- a/templates/quarkus-camel-api-consumer/template.yaml
+++ b/templates/quarkus-camel-api-consumer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Quarkus Camel REST consumer
   description: Create a simple REST consumer using Camel with Quarkus
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/quarkus-camel-api-producer/skeleton/.gitignore
+++ b/templates/quarkus-camel-api-producer/skeleton/.gitignore
@@ -5,6 +5,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
 .flattened-pom.xml
+src/main/openapi
 
 # Eclipse
 .project

--- a/templates/quarkus-camel-api-producer/skeleton/pom.xml
+++ b/templates/quarkus-camel-api-producer/skeleton/pom.xml
@@ -266,7 +266,7 @@
                         <artifact>
                             <groupId>${{ values.service_registry_group_id }}</groupId>
                             <artifactId>${{ values.api_id }}</artifactId>
-                            <file>${project.build.directory}/classes/api-registry/${{ values.api_id }}-api.json</file>
+                            <file>${project.basedir}/src/main/openapi/${{ values.api_id }}-api.json</file>
                             <overwrite>true</overwrite>
                         </artifact>
                     </artifacts>

--- a/templates/quarkus-camel-api-producer/skeleton/src/main/resources/application.properties
+++ b/templates/quarkus-camel-api-producer/skeleton/src/main/resources/application.properties
@@ -1,27 +1,11 @@
-## ---------------------------------------------------------------------------
-## Licensed to the Apache Software Foundation (ASF) under one or more
-## contributor license agreements.  See the NOTICE file distributed with
-## this work for additional information regarding copyright ownership.
-## The ASF licenses this file to You under the Apache License, Version 2.0
-## (the "License"); you may not use this file except in compliance with
-## the License.  You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-## ---------------------------------------------------------------------------
 quarkus.banner.enabled = false
+quarkus.management.port = 9000
+quarkus.native.resources.includes=productpage.json
+quarkus.camel.openapi.codegen.model-package=com.redhat.bookinfo.details
+quarkus.log.level=debug
 
-#
-# Camel
-#
 camel.context.name = ${{ values.component_id }}
-
 camel.main.routes-include-pattern = routes/*
 camel.component.rest-openapi.mockIncludePattern = file:camel-mock/**,classpath:camel-mock/**
-
-quarkus.management.port = 9000
+camel.rest.bindingPackageScan=${quarkus.camel.openapi.codegen.model-package}
+camel.rest.bindingMode=json

--- a/templates/quarkus-camel-api-producer/skeleton/src/main/resources/routes/${{ values.component_id }}-route.camel.yaml
+++ b/templates/quarkus-camel-api-producer/skeleton/src/main/resources/routes/${{ values.component_id }}-route.camel.yaml
@@ -1,17 +1,13 @@
 - rest:
     openApi:
       missingOperation: mock
-      specification: api-registry/${{ values.api_id }}-api.json
+      specification: ${{ values.api_id }}-api.json
 - route:
-    id: route-endpoint-4325
-    description: Route /path
+    id: sample-route
     from:
-      uri: direct:operationIdUpdateMe
+      uri: direct:someOperationId
       parameters: {}
       steps:
-        - unmarshal:
-            json:
-              library: Jackson
         - log:
             message: "${body}"
         - setBody:

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-dev.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-dev.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.component_id }}-dev
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-dev
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-dev.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-dev.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
 spec:
   project: default
   source:

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
 spec:
   project: default
   source:

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.component_id }}-pipeline
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-pipeline
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
 spec:
   project: default
   source:

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.component_id }}-prod
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-prod
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -20,6 +20,7 @@ spec:
         environment: prod
         image:
           tag: latest
+        replicaCount: 0
   destination:
     server: https://kubernetes.default.svc
     namespace: ${{values.application.split("/")[1]}}-prod

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
 spec:
   project: default
   source:

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -20,6 +20,7 @@ spec:
         environment: qa
         image:
           tag: latest
+        replicaCount: 0
   destination:
     server: https://kubernetes.default.svc
     namespace: ${{values.application.split("/")[1]}}-qa

--- a/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/quarkus-camel-api-producer/system/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.component_id }}-qa
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-qa
   namespace: openshift-gitops
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/templates/quarkus-camel-api-producer/template.yaml
+++ b/templates/quarkus-camel-api-producer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Quarkus Camel REST server
   description: Create a REST service using Camel with Quarkus (v0.2)
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/quarkus-camel-api-producer/template.yaml
+++ b/templates/quarkus-camel-api-producer/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: quarkus-camel-api-producer-template
   title: Quarkus Camel REST server
-  description: Create a REST service using Camel with Quarkus (v0.1)
+  description: Create a REST service using Camel with Quarkus (v0.2)
 spec:
   owner: service@example.com
   type: service
@@ -14,7 +14,6 @@ spec:
         - component_id
         - owner
         - java_group_id
-        - java_package
         - application
         - description
         - api
@@ -27,11 +26,8 @@ spec:
         java_group_id:
           title: Group Name
           type: string
-          description: Name for the group id, eg. (backstage in my.group)
-        java_package:
-          title: Java Package Name
-          type: string
-          description: Name for the java package. eg (package in my.package.name)
+          description: Name for the group id
+          default: com.redhat
         description:
           title: Description
           type: string
@@ -74,11 +70,6 @@ spec:
           ui:options:
             allowedKinds:
             - API
-        service_registry_provider_url:
-          title: Service Registry Provider URL
-          type: string
-          description: Apicurio Registry Host
-          default: https://registry-apicurio-registry.apps.cluster-example.com
         service_registry_group_id:
           title: Service Registry Group ID
           type: string
@@ -86,7 +77,8 @@ spec:
         cluster_domain:
           title: Cluster domain
           type: string
-          description: Cluster domain (like apps.example.com)   
+          description: Cluster domain (like apps.example.com)
+          default: apps.cluster-m22mk.m22mk.sandbox2534.opentlc.com
 
   steps:
     - id: template
@@ -101,7 +93,7 @@ spec:
           artifact_id: ${{ parameters.component_id }}
           folder_java_package: ${{ parameters.java_package | replace('.', '/') }}
           java_group_id: ${{ parameters.java_group_id }}
-          java_package: ${{ parameters.java_package }}
+          java_package: ${{ parameters.java_group_id }}.${{ parameters.component_id }}
           owner: ${{ parameters.owner }}
           destination: https://github.com/contract-first-idp/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
           project_slug: contract-first-idp/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
@@ -109,7 +101,7 @@ spec:
           service_id: ${{ parameters.component_id }}-service
           system_label: system=${{ parameters.application.split("/")[1] }}
           api_id: ${{ parameters.api.split("/")[1] }}
-          service_registry_provider_url: ${{ parameters.service_registry_provider_url }}
+          service_registry_provider_url: https://registry-apicurio-registry.${{ parameters.cluster_domain }}
           service_registry_group_id: ${{ parameters.service_registry_group_id }}
 
     - id: publish

--- a/templates/quarkus-camel-api-producer/template.yaml
+++ b/templates/quarkus-camel-api-producer/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: quarkus-camel-api-producer-template
   title: Quarkus Camel REST server
-  description: Create a REST service using Camel with Quarkus
+  description: Create a REST service using Camel with Quarkus (v0.1)
 spec:
   owner: service@example.com
   type: service
@@ -164,7 +164,7 @@ spec:
           deployment: ${{ parameters.deployment }}
         targetPath: ./system-gitops
 
-    - id: pull-request
+    - id: pr
       name: Open PR to System
       action: publish:github:pull-request
       input:
@@ -176,6 +176,8 @@ spec:
 
   output:
     links:
+      - title: Pull Request to System
+        url: ${{ steps.pr.output.remoteUrl }}
       - title: Repository
         url: ${{ steps.publish.output.remoteUrl }}
       - title: Open in catalog

--- a/templates/quarkus-camel-openapi/skeleton/.devfile.yaml
+++ b/templates/quarkus-camel-openapi/skeleton/.devfile.yaml
@@ -1,0 +1,79 @@
+schemaVersion: 2.2.0
+metadata:
+  name: ${{values.component_id}}
+  version: 0.0.1
+  displayName: CEQ Java ubi8
+  description: CEQ and ubi8 image
+  generateName: ${{values.component_id}}
+  icon: >-
+    https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/java-maven.jpg
+  tags:
+    - Java
+    - Quarkus
+    - Camel
+  projectType: quarkus
+  language: java
+attributes:
+  controller.devfile.io/storage-type: per-workspace
+components:
+  - name: development-tooling
+    container:
+      image: quay.io/devfile/universal-developer-image:latest
+      env:
+        - name: QUARKUS_HTTP_HOST
+          value: 0.0.0.0
+        - name: MAVEN_OPTS
+          value: "-Dmaven.repo.local=/home/user/.m2/repository"
+        - name: QUARKUS_ANALYTICS_DISABLED
+          value: "true"
+      memoryLimit: 5Gi
+      cpuLimit: 2500m
+      sourceMapping: $PROJECT_SOURCE
+      mountSources: true
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      endpoints:
+        - name: http-8778
+          targetPort: 8778
+        - name: devtools
+          targetPort: 8000
+        - name: http
+          targetPort: 8080
+          exposure: public
+          secure: false
+          protocol: http
+        - name: http-8443
+          targetPort: 8443
+        - name: debug
+          targetPort: 5005
+          exposure: none
+          secure: false
+          protocol: tcp
+  - name: m2
+    volume:
+      size: 1G
+commands:
+  - id: package
+    exec:
+      label: "1. Package the application"
+      component: development-tooling
+      commandLine: "./mvnw package"
+      group:
+        kind: build
+        isDefault: true
+  - id: start-dev
+    exec:
+      label: "2. Start Development mode (Hot reload + debug)"
+      component: development-tooling
+      commandLine: "./mvnw compile quarkus:dev"
+      group:
+        kind: run
+        isDefault: true
+  - id: fix-java-version
+    exec:
+      component: development-tooling
+      commandLine: 'rm -rf ${HOME}/.java/current/* && ln -s /usr/lib/jvm/java-17-openjdk/* ${HOME}/.java/current'
+events:
+  postStart:
+    - fix-java-version

--- a/templates/quarkus-camel-openapi/skeleton/.gitignore
+++ b/templates/quarkus-camel-openapi/skeleton/.gitignore
@@ -1,0 +1,40 @@
+#Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+.flattened-pom.xml
+src/main/openapi
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# NetBeans
+nb-configuration.xml
+
+# Visual Studio Code
+.factorypath
+
+# OSX
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Local environment
+.env

--- a/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/.gitignore
+++ b/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/.gitignore
@@ -1,0 +1,1 @@
+maven-wrapper.jar

--- a/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader
+{
+    private static final String WRAPPER_VERSION = "3.1.1";
+
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL =
+        "https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/" + WRAPPER_VERSION
+            + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to use instead of the
+     * default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH = ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH = ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main( String args[] )
+    {
+        System.out.println( "- Downloader started" );
+        File baseDirectory = new File( args[0] );
+        System.out.println( "- Using base directory: " + baseDirectory.getAbsolutePath() );
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File( baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH );
+        String url = DEFAULT_DOWNLOAD_URL;
+        if ( mavenWrapperPropertyFile.exists() )
+        {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try
+            {
+                mavenWrapperPropertyFileInputStream = new FileInputStream( mavenWrapperPropertyFile );
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load( mavenWrapperPropertyFileInputStream );
+                url = mavenWrapperProperties.getProperty( PROPERTY_NAME_WRAPPER_URL, url );
+            }
+            catch ( IOException e )
+            {
+                System.out.println( "- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'" );
+            }
+            finally
+            {
+                try
+                {
+                    if ( mavenWrapperPropertyFileInputStream != null )
+                    {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                }
+                catch ( IOException e )
+                {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println( "- Downloading from: " + url );
+
+        File outputFile = new File( baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH );
+        if ( !outputFile.getParentFile().exists() )
+        {
+            if ( !outputFile.getParentFile().mkdirs() )
+            {
+                System.out.println( "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath()
+                    + "'" );
+            }
+        }
+        System.out.println( "- Downloading to: " + outputFile.getAbsolutePath() );
+        try
+        {
+            downloadFileFromURL( url, outputFile );
+            System.out.println( "Done" );
+            System.exit( 0 );
+        }
+        catch ( Throwable e )
+        {
+            System.out.println( "- Error downloading" );
+            e.printStackTrace();
+            System.exit( 1 );
+        }
+    }
+
+    private static void downloadFileFromURL( String urlString, File destination )
+        throws Exception
+    {
+        if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
+        {
+            String username = System.getenv( "MVNW_USERNAME" );
+            char[] password = System.getenv( "MVNW_PASSWORD" ).toCharArray();
+            Authenticator.setDefault( new Authenticator()
+            {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication()
+                {
+                    return new PasswordAuthentication( username, password );
+                }
+            } );
+        }
+        URL website = new URL( urlString );
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel( website.openStream() );
+        FileOutputStream fos = new FileOutputStream( destination );
+        fos.getChannel().transferFrom( rbc, 0, Long.MAX_VALUE );
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/maven-wrapper.properties
+++ b/templates/quarkus-camel-openapi/skeleton/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/templates/quarkus-camel-openapi/skeleton/.vscode/extensions.json
+++ b/templates/quarkus-camel-openapi/skeleton/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["redhat.apache-camel-extension-pack"]
+}

--- a/templates/quarkus-camel-openapi/skeleton/catalog-info.yaml
+++ b/templates/quarkus-camel-openapi/skeleton/catalog-info.yaml
@@ -1,0 +1,26 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{values.component_id | dump}}
+  description: ${{values.description | dump}}
+  tags:
+    - java
+  links:
+    - url: https://devspaces.apps.cluster-m22mk.m22mk.sandbox2534.opentlc.com/?storageType=per-workspace#${{values.destination}}
+      title: OpenShift Dev Spaces
+      icon: web
+    - url: https://hawtio-online-hawtio-operator.apps.cluster-m22mk.m22mk.sandbox2534.opentlc.com/online/discover?namespace=${{values.system_label}}
+      title: HawtIO
+      icon: web
+  annotations:
+    github.com/project-slug: ${{values.project_slug | dump}}
+    backstage.io/kubernetes-id: ${{values.component_id | dump}}
+    backstage.io/kubernetes-label-selector: ${{values.system_label | dump}}
+    janus-idp.io/tekton : ${{values.service_id | dump}}
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{values.owner | dump}}
+  system: ${{values.application}}
+  providesApis: 
+    - ${{values.api_id}}

--- a/templates/quarkus-camel-openapi/skeleton/eclipse-formatter-config.xml
+++ b/templates/quarkus-camel-openapi/skeleton/eclipse-formatter-config.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<profiles version="8">
+    <profile name="Camel Java Conventions" version="8" kind="CodeFormatterProfile">
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_return_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="8"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="128"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="CHECKSTYLE:OFF"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="CHECKSTYLE:ON"/>
+    </profile>
+</profiles>

--- a/templates/quarkus-camel-openapi/skeleton/mvnw
+++ b/templates/quarkus-camel-openapi/skeleton/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/templates/quarkus-camel-openapi/skeleton/mvnw.cmd
+++ b/templates/quarkus-camel-openapi/skeleton/mvnw.cmd
@@ -1,0 +1,205 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%

--- a/templates/quarkus-camel-openapi/skeleton/pom.xml
+++ b/templates/quarkus-camel-openapi/skeleton/pom.xml
@@ -95,6 +95,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-jsonpath</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-http</artifactId>
+        </dependency>
         <!--
             This dependency is mandatory for enabling Camel management
             via JMX / Hawtio.
@@ -140,12 +144,7 @@
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>${formatter-maven-plugin.version}</version>
-                    <configuration><artifact>
-                            <groupId>${{ values.service_registry_group_id }}</groupId>
-                            <artifactId>${{ values.api_id }}</artifactId>
-                            <file>${project.basedir}/src/main/openapi/${{ values.api_id }}-api.json</file>
-                            <overwrite>true</overwrite>
-                        </artifact>
+                    <configuration>
                         <configFile>
                             ${project.basedir}/eclipse-formatter-config.xml</configFile>
                         <lineEnding>LF</lineEnding>
@@ -272,6 +271,12 @@
                             <groupId>${{ values.service_registry_group_id }}</groupId>
                             <artifactId>${{ values.api_id }}</artifactId>
                             <file>${project.basedir}/src/main/openapi/${{ values.api_id }}-api.json</file>
+                            <overwrite>true</overwrite>
+                        </artifact>
+                        <artifact>
+                            <groupId>${{ values.service_registry_group_id }}</groupId>
+                            <artifactId>${{ values.consumed_api_id }}</artifactId>
+                            <file>${project.basedir}/src/main/openapi/${{ values.consumed_api_id }}-api.json</file>
                             <overwrite>true</overwrite>
                         </artifact>
                     </artifacts>

--- a/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.jvm
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,106 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+
+ENV LANGUAGE='en_US:en'
+
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 target/quarkus-app/*.jar /deployments/
+COPY --chown=185 target/quarkus-app/app/ /deployments/app/
+COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+USER root
+
+ADD https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.1.1/jolokia-agent-jvm-2.1.1-javaagent.jar /opt/jolokia/jolokia-javaagent.jar
+
+RUN \
+    chown 185:185 -R /opt/jolokia \
+    && chmod -R go+r /opt/jolokia/jolokia-javaagent.jar
+
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/opt/jolokia/jolokia-javaagent.jar=host=0.0.0.0,port=8778,protocol=https,useSslClientAuthentication=true,caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
+EXPOSE 8080 8778 9000
+USER 185
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+

--- a/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.legacy-jar
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.legacy-jar
@@ -1,0 +1,93 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dquarkus.package.jar.type=legacy-jar
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/code-with-quarkus-legacy-jar .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-legacy-jar
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-legacy-jar
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+
+ENV LANGUAGE='en_US:en'
+
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/quarkus-run.jar
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.native
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.native-micro
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/docker/Dockerfile.native-micro
@@ -1,0 +1,30 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM quay.io/quarkus/quarkus-micro-image:2.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/templates/quarkus-camel-openapi/skeleton/src/main/java/${{ values.folder_java_package }}/ApiRoute.java
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/java/${{ values.folder_java_package }}/ApiRoute.java
@@ -1,0 +1,23 @@
+package ${{ values.java_package }};
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestBindingMode;
+
+@ApplicationScoped
+public class ApiRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        restConfiguration().bindingMode(RestBindingMode.json)
+                .bindingPackageScan("${{ values.java_package }}");
+
+        rest().openApi().specification("${{ values.api_id }}-api.json").missingOperation("ignore");
+
+        from("direct:sampleOperationId")
+                .removeHeaders("*")
+                .to("rest-openapi:${{ values.consumed_api_id }}-api.json#${{ values.consumed_api_operation }}?host={{openapi.client.${{ values.consumed_api_id }}.host}}");
+
+    }
+}

--- a/templates/quarkus-camel-openapi/skeleton/src/main/resources/application.properties
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/resources/application.properties
@@ -4,7 +4,8 @@ quarkus.native.resources.includes=${{ values.component_id }}-api.json
 quarkus.camel.openapi.codegen.model-package=${{ values.java_package }}
 
 camel.context.name = ${{ values.component_id }}
-camel.main.routes-include-pattern = routes/*
 camel.component.rest-openapi.mockIncludePattern = file:camel-mock/**,classpath:camel-mock/**
 camel.rest.bindingPackageScan=${quarkus.camel.openapi.codegen.model-package}
 camel.rest.bindingMode=json
+
+openapi.client.${{ values.consumed_api_id }}.host=http://${{ values.consumed_api_id }}:8080

--- a/templates/quarkus-camel-openapi/skeleton/src/main/resources/camel-mock/README.md
+++ b/templates/quarkus-camel-openapi/skeleton/src/main/resources/camel-mock/README.md
@@ -1,0 +1,25 @@
+# Mocking API operations
+
+This is similar to ignoring missing API operations, as you can tell Camel to mock instead, as shown:
+
+`rest().openApi("petstore-v3.json").missingOperation("mock");`
+
+When using mock, then Camel will (for missing operations) simulate a successful response:
+
+1. attempting to load canned responses from the file system.
+2. for GET verbs then attempt to use example inlined in the OpenAPI response section.
+3. for other verbs (DELETE, PUT, POST, PATCH) then return the input body as response.
+4. if none of the above, then return empty body.
+
+For the url `pet/123` the file `camel-mock/pet/123.json` will be loaded as the response as shown below:
+
+```bash
+$ curl http://0.0.0.0:8080/api/v3/pet/123
+{
+  "pet": "donald the dock"
+}
+```
+
+If no file is found, then Camel will attempt to find an example from the response section in the OpenAPI specification.
+
+Read more details at https://camel.apache.org/manual/rest-dsl-openapi.html#_mocking_api_operations

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-dev.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-dev.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-dev
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-camel/developer-charts
+    targetRevision: HEAD
+    path: quarkus-application
+    helm:
+      values: |
+        system: ${{values.application.split("/")[1]}}
+        component: ${{ values.component_id }}
+        environment: dev
+        image:
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-dev
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-pipeline.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-pipeline
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-camel/developer-charts
+    targetRevision: HEAD
+    path: quarkus-pipeline
+    helm:
+      values: |
+        domain: contract-first-camel
+        system: ${{values.application.split("/")[1]}}
+        component: ${{ values.component_id }}
+        deployment: ${{ values.deployment }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-build
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-prod
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-camel/developer-charts
+    targetRevision: HEAD
+    path: quarkus-application
+    helm:
+      values: |
+        system: ${{values.application.split("/")[1]}}
+        component: ${{ values.component_id }}
+        environment: prod
+        image:
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-prod
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-prod.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-prod.yaml
@@ -20,6 +20,7 @@ spec:
         environment: prod
         image:
           tag: latest
+        replicaCount: 0
   destination:
     server: https://kubernetes.default.svc
     namespace: ${{values.application.split("/")[1]}}-prod

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -20,6 +20,7 @@ spec:
         environment: qa
         image:
           tag: latest
+        replicaCount: 0
   destination:
     server: https://kubernetes.default.svc
     namespace: ${{values.application.split("/")[1]}}-qa

--- a/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-qa.yaml
+++ b/templates/quarkus-camel-openapi/system/components/${{values.component_id}}-argocd-app-qa.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${{values.application.split("/")[1]}}-${{ values.component_id }}-qa
+  namespace: openshift-gitops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application.split("/")[1]}}
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/contract-first-camel/developer-charts
+    targetRevision: HEAD
+    path: quarkus-application
+    helm:
+      values: |
+        system: ${{values.application.split("/")[1]}}
+        component: ${{ values.component_id }}
+        environment: qa
+        image:
+          tag: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ${{values.application.split("/")[1]}}-qa
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=false
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m

--- a/templates/quarkus-camel-openapi/template.yaml
+++ b/templates/quarkus-camel-openapi/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Quarkus Camel OpenAPI
   description: OpenAPI server and client using Camel with Quarkus (v0.9)
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/quarkus-camel-openapi/template.yaml
+++ b/templates/quarkus-camel-openapi/template.yaml
@@ -1,9 +1,9 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: quarkus-camel-api-producer-template
-  title: Quarkus Camel REST server
-  description: Create a REST service using Camel with Quarkus (v0.2)
+  name: quarkus-camel-openapi-template
+  title: Quarkus Camel OpenAPI
+  description: OpenAPI server and client using Camel with Quarkus (v0.9)
 spec:
   owner: service@example.com
   type: service
@@ -17,6 +17,8 @@ spec:
         - application
         - description
         - api
+        - consumed_api
+        - consumed_api_operation
         - cluster_domain
       properties:
         component_id:
@@ -70,6 +72,17 @@ spec:
           ui:options:
             allowedKinds:
             - API
+        consumed_api:
+          title: Consumed API
+          type: string
+          description: The API being consumed
+          ui:field: OwnedEntityPicker
+          ui:options:
+            allowedKinds:
+            - API
+        consumed_api_operation:
+          title: Operation to invoke on the consumed API
+          type: string
         service_registry_group_id:
           title: Service Registry Group ID
           type: string
@@ -91,16 +104,18 @@ spec:
           component_id: ${{ parameters.component_id }}
           description: ${{ parameters.description }}
           artifact_id: ${{ parameters.component_id }}
-          folder_java_package: ${{ parameters.java_package | replace('.', '/') }}
+          folder_java_package: ${{ parameters.java_group_id | replace('.', '/') }}/${{ parameters.application.split("/")[1] }}/${{ parameters.component_id }}
           java_group_id: ${{ parameters.java_group_id }}
           java_package: ${{ parameters.java_group_id }}.${{ parameters.application.split("/")[1] }}.${{ parameters.component_id }}
           owner: ${{ parameters.owner }}
-          destination: https://github.com/contract-first-idp/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
-          project_slug: contract-first-idp/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
+          destination: https://github.com/contract-first-camel/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
+          project_slug: contract-first-camel/${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service
           application: ${{ parameters.application }}
           service_id: ${{ parameters.component_id }}-service
           system_label: system=${{ parameters.application.split("/")[1] }}
           api_id: ${{ parameters.api.split("/")[1] }}
+          consumed_api_id: ${{ parameters.consumed_api.split("/")[1] }}
+          consumed_api_operation: ${{ parameters.consumed_api_operation }}
           service_registry_provider_url: https://registry-apicurio-registry.${{ parameters.cluster_domain }}
           service_registry_group_id: ${{ parameters.service_registry_group_id }}
 
@@ -110,7 +125,7 @@ spec:
       input:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.component_id }}
-        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service&owner=contract-first-idp
+        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service&owner=contract-first-camel
         repoVisibility: public
         defaultBranch: main
         deleteBranchOnMerge: true
@@ -120,7 +135,7 @@ spec:
       name: webhook creation source repository
       action: github:webhook
       input:
-        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service&owner=contract-first-idp
+        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-service&owner=contract-first-camel
         webhookUrl: https://webhook-${{ parameters.application.split("/")[1] }}-${{ parameters.component_id }}-el-${{ parameters.application.split("/")[1] }}-build.${{ parameters.cluster_domain }}
         webhookSecret: 'mysecret'
         events: [ 'push' ]
@@ -150,7 +165,7 @@ spec:
           java_package: ${{ parameters.java_package }}
           owner: ${{ parameters.owner }}
           application: ${{ parameters.application }}
-          organization: contract-first-idp
+          organization: contract-first-camel
           team: ${{ parameters.owner }}
           repo_id: ${{ parameters.component_id }}
           deployment: ${{ parameters.deployment }}
@@ -160,7 +175,7 @@ spec:
       name: Open PR to System
       action: publish:github:pull-request
       input:
-        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-system&owner=contract-first-idp
+        repoUrl: github.com?repo=${{ parameters.application.split("/")[1] }}-system&owner=contract-first-camel
         branchName: ${{ parameters.component_id }}-component
         title: add ${{ parameters.component_id }} component
         description: add ${{ parameters.component_id }} component

--- a/templates/spring-boot-api-consumer/template.yaml
+++ b/templates/spring-boot-api-consumer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Spring Boot REST consumer
   description: Create a simple REST consumer
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/spring-boot-api-producer/template.yaml
+++ b/templates/spring-boot-api-producer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Spring Boot REST server
   description: Create a simple RESTful microservice using Spring Boot
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/spring-boot-camel-api-consumer/template.yaml
+++ b/templates/spring-boot-camel-api-consumer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Spring Boot Camel REST consumer
   description: Create a simple REST consumer using Camel with Spring Boot
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/spring-boot-camel-api-producer/template.yaml
+++ b/templates/spring-boot-camel-api-producer/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: Spring Boot Camel REST server
   description: Create a REST service using Camel with Spring Boot
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: service
   
   parameters:

--- a/templates/system/domain/argoapps/${{values.application_id}}-system.yaml
+++ b/templates/system/domain/argoapps/${{values.application_id}}-system.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  labels:
+    system: ${{values.application_id}}
 spec:
   project: default
   source:

--- a/templates/system/template.yaml
+++ b/templates/system/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: system-template
   title: System Template
-  description: Create a System to contain a set of application Components, APIs, and Resources
+  description: Create a System to contain a set of application Components, APIs, and Resources (v0.3)
 spec:
   owner: service@example.com
   type: system
@@ -30,8 +30,7 @@ spec:
           ui:field: OwnerPicker
           ui:options:
             allowedKinds: 
-              - Group      
-
+              - Group
   steps:
 
     - id: template-system
@@ -45,7 +44,7 @@ spec:
           description: ${{ parameters.description }}
           owner: ${{ parameters.owner }}
 
-    - id: publish-system
+    - id: publish
       name: publish system manifest repository
       action: publish:github
       input:
@@ -56,6 +55,13 @@ spec:
         defaultBranch: main
         deleteBranchOnMerge: true
         protectDefaultBranch: false
+
+    - id: register
+      name: register system entity
+      action: catalog:register
+      input:
+        repoContentsUrl: '${{ steps.publish.output.repoContentsUrl }}'
+        catalogInfoPath: '/catalog-info.yaml'
 
     - id: template-domain-pull-request
       name: render domain pull request
@@ -69,7 +75,7 @@ spec:
           owner: ${{ parameters.owner }}
         targetPath: ./domain-gitops  
 
-    - id: pull-request-to-domain
+    - id: pr
       name: open domain pull request
       action: publish:github:pull-request
       input:
@@ -78,3 +84,13 @@ spec:
         title: add ${{ parameters.application_id }} system
         description: add ${{ parameters.application_id }} system
         sourcePath: ./domain-gitops
+
+  output:
+    links:
+      - title: Pull Request to Domain
+        url: ${{ steps.pr.output.remoteUrl }}
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}

--- a/templates/system/template.yaml
+++ b/templates/system/template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: System Template
   description: Create a System to contain a set of application Components, APIs, and Resources (v0.3)
 spec:
-  owner: service@example.com
+  owner: backstage-admin@redhat.com
   type: system
 
   parameters:

--- a/templates/system/template.yaml
+++ b/templates/system/template.yaml
@@ -14,7 +14,6 @@ spec:
         - application_id
         - owner
         - description
-        - cluster_domain
       properties:
         application_id:
           title: Name
@@ -31,11 +30,7 @@ spec:
           ui:field: OwnerPicker
           ui:options:
             allowedKinds: 
-              - Group
-        cluster_domain:
-          title: Cluster domain
-          type: string
-          description: Cluster domain (like apps.example.com)        
+              - Group      
 
   steps:
 


### PR DESCRIPTION
- add labels to ArgoCD Applications and apply naming convention for grouping and to avoid collision
- register entities
- add pr and repo links to template output
- consolidate template params requiring cluster URL to just one cluster URL field
- fix model generation for Camel openapi component
- add camel OpenAPI producer/consumer template
- start qa and prod deployments at zero replicas
- add links to mock URL and schema registry for APIs

These improvements need to be ported to all relevant templates